### PR TITLE
Add LocalDate scalar type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ plugins {
 
 group = 'com.msalvatore'
 version = '0.0.1-SNAPSHOT'
-// TODO: Change to 13?
-sourceCompatibility = '11'
+sourceCompatibility = '13'
 
 repositories {
 	mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Dec 05 09:47:22 EST 2019
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/msalvatore/graphqlplayground/Application.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/Application.java
@@ -1,13 +1,20 @@
 package com.msalvatore.graphqlplayground;
 
+import com.msalvatore.graphqlplayground.scalar.datetime.GraphQLLocalDate;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Application.class, args);
+	}
+
+	@Bean
+	public GraphQLLocalDate graphQLLocalDate() {
+		return new GraphQLLocalDate();
 	}
 
 }

--- a/src/main/java/com/msalvatore/graphqlplayground/entity/Vehicle.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/entity/Vehicle.java
@@ -1,11 +1,14 @@
 package com.msalvatore.graphqlplayground.entity;
 
-import javax.persistence.*;
-import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import java.time.LocalDate;
 
-@Entity
-public class Vehicle implements Serializable {
+@Entity(name = "VEHICLES")
+public class Vehicle {
 
     private static final long serialVersionUID = 1L;
 
@@ -14,16 +17,16 @@ public class Vehicle implements Serializable {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private int id;
 
-    @Column(name = "type", nullable = false)
+    @Column(name = "TYPE", nullable = false)
     private String type;
 
-    @Column(name = "model_code", nullable = false)
+    @Column(name = "MODEL_CODE", nullable = false)
     private String modelCode;
 
-    @Column(name = "brand_name")
+    @Column(name = "BRAND_NAME")
     private String brandName;
 
-    @Column(name = "launch_date")
+    @Column(name = "LAUNCH_DATE")
     private LocalDate launchDate;
 
     private transient  String formattedDate;

--- a/src/main/java/com/msalvatore/graphqlplayground/mutation/VehicleMutation.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/mutation/VehicleMutation.java
@@ -5,6 +5,8 @@ import com.msalvatore.graphqlplayground.entity.Vehicle;
 import com.msalvatore.graphqlplayground.service.VehicleService;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+
 @Component
 public class VehicleMutation implements GraphQLMutationResolver {
 
@@ -14,7 +16,7 @@ public class VehicleMutation implements GraphQLMutationResolver {
         this.vehicleService = vehicleService;
     }
 
-    public Vehicle createVehicle(String type, String modelCode, String brandName, String launchDate) {
+    public Vehicle createVehicle(String type, String modelCode, String brandName, LocalDate launchDate) {
         // TODO: Can we accept a LocalDate instead of a String?
         return vehicleService.createVehicle(type, modelCode, brandName, launchDate);
     }

--- a/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/DateTimeHelper.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/DateTimeHelper.java
@@ -1,0 +1,97 @@
+package com.msalvatore.graphqlplayground.scalar.datetime;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+public class DateTimeHelper {
+
+    public static final CopyOnWriteArrayList<DateTimeFormatter> DATE_FORMATTERS = new CopyOnWriteArrayList<>();
+
+    static {
+        DATE_FORMATTERS.add(DateTimeFormatter.ISO_INSTANT.withZone(ZoneOffset.UTC));
+        DATE_FORMATTERS.add(DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(ZoneOffset.UTC));
+        DATE_FORMATTERS.add(DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneOffset.UTC));
+    }
+
+    // ISO_8601
+    public static String toISOString(LocalDateTime dateTime) {
+        Objects.requireNonNull(dateTime, "dateTime");
+
+        return DateTimeFormatter.ISO_INSTANT.format(ZonedDateTime.of(dateTime, ZoneOffset.UTC));
+    }
+
+    public static String toISOString(LocalDate date) {
+        Objects.requireNonNull(date, "date");
+
+        return DateTimeFormatter.ISO_LOCAL_DATE.format(date);
+    }
+
+    public static String toISOString(LocalTime time) {
+        Objects.requireNonNull(time, "time");
+
+        return DateTimeFormatter.ISO_LOCAL_TIME.format(time);
+    }
+
+    public static String toISOString(Date date) {
+        Objects.requireNonNull(date, "date");
+
+        return toISOString(toLocalDateTime(date));
+    }
+
+    public static LocalDateTime toLocalDateTime(Date date) {
+        Objects.requireNonNull(date, "date");
+
+        return date.toInstant().atZone(ZoneOffset.UTC).toLocalDateTime();
+    }
+
+    public static Date toDate(LocalDate date) {
+        Objects.requireNonNull(date, "date");
+
+        return toDate(date.atStartOfDay());
+    }
+
+    public static Date toDate(LocalDateTime dateTime) {
+        Objects.requireNonNull(dateTime, "dateTime");
+
+        return Date.from(dateTime.atZone(ZoneOffset.UTC).toInstant());
+    }
+
+    public static LocalDateTime parseDate(String date) {
+        Objects.requireNonNull(date, "date");
+
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                // equals ISO_LOCAL_DATE
+                if (formatter.equals(DATE_FORMATTERS.get(2))) {
+                    LocalDate localDate = LocalDate.parse(date, formatter);
+
+                    return localDate.atStartOfDay();
+                } else {
+                    return LocalDateTime.parse(date, formatter);
+                }
+            } catch (java.time.format.DateTimeParseException ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    public static Date createDate(int year, int month, int day) {
+        return createDate(year, month, day, 0, 0, 0, 0);
+    }
+
+    public static Date createDate(int year, int month, int day, int hours, int min, int sec) {
+        return createDate(year, month, day, hours, min, sec, 0);
+    }
+
+    public static Date createDate(int year, int month, int day, int hours, int min, int sec, int millis) {
+        long nanos = TimeUnit.MILLISECONDS.toNanos(millis);
+        LocalDateTime localDateTime = LocalDateTime.of(year, month, day, hours, min, sec, (int) nanos);
+        return DateTimeHelper.toDate(localDateTime);
+    }
+
+}

--- a/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/GraphQLLocalDate.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/GraphQLLocalDate.java
@@ -1,0 +1,73 @@
+package com.msalvatore.graphqlplayground.scalar.datetime;
+
+import graphql.language.StringValue;
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+// TODO: This could probably be simplified/re-written, but it's a proof of concept ¯\_(ツ)_/¯
+// Taken from https://github.com/donbeave/graphql-java-datetime
+public class GraphQLLocalDate extends GraphQLScalarType {
+
+    private static final String DEFAULT_NAME = "LocalDate";
+
+    public GraphQLLocalDate() {
+        this(DEFAULT_NAME, false);
+    }
+
+    public GraphQLLocalDate(boolean zoneConversionEnabled) {
+        this(DEFAULT_NAME, zoneConversionEnabled);
+    }
+
+    public GraphQLLocalDate(final String name, boolean zoneConversionEnabled) {
+        super(name, "Local Date type", new Coercing<LocalDate, String>() {
+
+            private LocalDateTimeConverter converter = new LocalDateTimeConverter(zoneConversionEnabled);
+
+            private LocalDate convertImpl(Object input) {
+                if (input instanceof String) {
+                    LocalDateTime localDateTime = converter.parseDate((String) input);
+
+                    if (localDateTime != null) {
+                        return localDateTime.toLocalDate();
+                    }
+                }
+                return null;
+            }
+
+            @Override
+            public String serialize(Object input) {
+                if (input instanceof LocalDate) {
+                    return DateTimeHelper.toISOString((LocalDate) input);
+                } else {
+                    LocalDate result = convertImpl(input);
+                    if (result == null) {
+                        throw new CoercingSerializeException("Invalid value '" + input + "' for LocalDate");
+                    }
+                    return DateTimeHelper.toISOString(result);
+                }
+            }
+
+            @Override
+            public LocalDate parseValue(Object input) {
+                LocalDate result = convertImpl(input);
+                if (result == null) {
+                    throw new CoercingParseValueException("Invalid value '" + input + "' for LocalDate");
+                }
+                return result;
+            }
+
+            @Override
+            public LocalDate parseLiteral(Object input) {
+                if (!(input instanceof StringValue)) return null;
+                String value = ((StringValue) input).getValue();
+                return convertImpl(value);
+            }
+        });
+    }
+
+}

--- a/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/LocalDateTimeConverter.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/scalar/datetime/LocalDateTimeConverter.java
@@ -1,0 +1,64 @@
+package com.msalvatore.graphqlplayground.scalar.datetime;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+import static com.msalvatore.graphqlplayground.scalar.datetime.DateTimeHelper.DATE_FORMATTERS;
+
+class LocalDateTimeConverter {
+
+    private boolean zoneConversionEnabled;
+
+    LocalDateTimeConverter(boolean zoneConversionEnabled) {
+        this.zoneConversionEnabled = zoneConversionEnabled;
+    }
+
+    // ISO_8601
+    String toISOString(LocalDateTime dateTime) {
+        Objects.requireNonNull(dateTime, "dateTime");
+
+        return DateTimeFormatter.ISO_INSTANT.format(ZonedDateTime.of(toUTC(dateTime), ZoneOffset.UTC));
+    }
+
+    LocalDateTime parseDate(String date) {
+        Objects.requireNonNull(date, "date");
+
+        for (DateTimeFormatter formatter : DATE_FORMATTERS) {
+            try {
+                // equals ISO_LOCAL_DATE
+                if (formatter.equals(DATE_FORMATTERS.get(2))) {
+                    LocalDate localDate = LocalDate.parse(date, formatter);
+
+                    return localDate.atStartOfDay();
+                } else {
+                    LocalDateTime dateTime = LocalDateTime.parse(date, formatter);
+                    return fromUTC(dateTime);
+                }
+            } catch (java.time.format.DateTimeParseException ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    private LocalDateTime convert(LocalDateTime dateTime, ZoneId from, ZoneId to) {
+        if (zoneConversionEnabled) {
+            return dateTime.atZone(from).withZoneSameInstant(to).toLocalDateTime();
+        }
+        return dateTime;
+    }
+
+    private LocalDateTime fromUTC(LocalDateTime dateTime) {
+        return convert(dateTime, ZoneOffset.UTC, ZoneId.systemDefault());
+    }
+
+    private LocalDateTime toUTC(LocalDateTime dateTime) {
+        return convert(dateTime, ZoneId.systemDefault(), ZoneOffset.UTC);
+    }
+
+}

--- a/src/main/java/com/msalvatore/graphqlplayground/service/VehicleService.java
+++ b/src/main/java/com/msalvatore/graphqlplayground/service/VehicleService.java
@@ -19,12 +19,12 @@ public class VehicleService {
     }
 
     @Transactional
-    public Vehicle createVehicle(String type, String modelCode, String brandName, String launchDate) {
+    public Vehicle createVehicle(String type, String modelCode, String brandName, LocalDate launchDate) {
         final Vehicle vehicle = new Vehicle();
         vehicle.setType(type);
         vehicle.setModelCode(modelCode);
         vehicle.setBrandName(brandName);
-        vehicle.setLaunchDate(LocalDate.parse(launchDate));
+        vehicle.setLaunchDate(launchDate);
         return vehicleRepository.save(vehicle);
     }
 

--- a/src/main/resources/graphql/scalars.graphqls
+++ b/src/main/resources/graphql/scalars.graphqls
@@ -1,0 +1,2 @@
+# java.time.LocalDate implementation
+scalar LocalDate

--- a/src/main/resources/graphql/vehicle.graphqls
+++ b/src/main/resources/graphql/vehicle.graphqls
@@ -3,7 +3,7 @@ type Vehicle {
     type: String,
     modelCode: String,
     brandName: String,
-    launchDate: String
+    launchDate: LocalDate
 }
 type Query {
     vehicles(count: Int):[Vehicle]


### PR DESCRIPTION
I noticed we were using a date string rather than a `LocalDate` in the vehicle GraphQL schema. I initially figured I was missing a JSR library (like with normal Boot MVC) to support `java.time` classes, but it wasn't as simple as that.

Note that I first tried using the [Boot datetime starter](https://github.com/donbeave/graphql-java-datetime) (although, I don't think it's an official starter at this point), which does not work out of the box. If you use it with older GraphQL-Java versions you get a duplicate bean exception on startup. If you use it with the newer version you get exceptions on startup because a class has moved packages. This was probably a good thing anyway since it forced me to dig deeper to see how scalars are wired up.