### PR TITLE
Enable Spring GraphQL exception handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,24 +178,20 @@ query {
 }
 ```
 Response
->This is a WIP. No exception details are coming back to the caller which is not ideal.
 ```json
 {
-    "data": {
-        "vehicle": null
-    },
     "errors": [
         {
-            "message": "Internal Server Error(s) while executing query",
-            "path": null,
-            "extensions": null
+            "message": "Vehicle with id 999 not found"
         }
-    ]
+    ],
+    "data": {
+        "updateVehicle": null
+    }
 }
 ```
 
 ## What's Next?
-* Improve error handling - GraphQL returns 200 status code with generic error message when any exceptions occur
 * Create sample integration test
   * can we use libs that we're already pulling in to build client request?
   * see what graphql-spring-boot-starter-test offers

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 # TODO: Either use or remove these
-#graphql:
-#  servlet:
+graphql:
+  servlet:
 #    mapping: /graphql
 #    enabled: true
 #    corsEnabled: true
-#    # if you want to @ExceptionHandler annotation for custom GraphQLErrors
-#    exception-handlers-enabled: true
+    exception-handlers-enabled: true
 #    contextSetting: PER_REQUEST_WITH_INSTRUMENTATION
+


### PR DESCRIPTION
I started out thinking we would need a custom exception handler, but the baked in Spring starter one seems to do enough when enabled. We can improve this later if we want to add something like a message code so the UI can change behavior as necessary (without string matching or a generic error message).